### PR TITLE
feat(librewolf): populate stylus catppuccin userstyles

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -134,6 +134,46 @@
         "type": "github"
       }
     },
+    "catppuccin-userstyles": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1749817927,
+        "narHash": "sha256-lftRs+pfcOrqHDtDWX/Vd/CQvDJguCRxlhI/aIkIB/k=",
+        "owner": "catppuccin",
+        "repo": "userstyles",
+        "rev": "714b153c7022c362a37ab8530286a87e4484a828",
+        "type": "github"
+      },
+      "original": {
+        "owner": "catppuccin",
+        "repo": "userstyles",
+        "type": "github"
+      }
+    },
+    "catppuccin-userstyles-nix": {
+      "inputs": {
+        "catppuccin-userstyles": "catppuccin-userstyles",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-deno": "nixpkgs-deno",
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1750928136,
+        "narHash": "sha256-0o0u/PUtR9thghbLUJrwLMcFEYBBY2DXjEo5FZHyWOk=",
+        "owner": "different-name",
+        "repo": "catppuccin-userstyles-nix",
+        "rev": "75d5e2af82ec4a5ce3defdd9f199dd0739c749c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "different-name",
+        "repo": "catppuccin-userstyles-nix",
+        "type": "github"
+      }
+    },
     "devshell": {
       "inputs": {
         "nixpkgs": [
@@ -281,7 +321,7 @@
     "flake-utils": {
       "inputs": {
         "systems": [
-          "ignis",
+          "catppuccin-userstyles-nix",
           "systems"
         ]
       },
@@ -323,26 +363,8 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
         "systems": [
-          "nix-yazi-plugins",
+          "ignis",
           "systems"
         ]
       },
@@ -360,13 +382,37 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": [
+          "nix-yazi-plugins",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -421,6 +467,21 @@
       }
     },
     "flake-utils_8": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_9": {
       "locked": {
         "lastModified": 1653893745,
         "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
@@ -607,12 +668,12 @@
     },
     "ignis": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "gvc": "gvc",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1747422394,
@@ -659,7 +720,7 @@
     },
     "lix-module": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "flakey-profile": "flakey-profile",
         "lix": "lix",
         "nixpkgs": [
@@ -775,13 +836,13 @@
     },
     "nix-yazi-plugins": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "flake-utils-plus": "flake-utils-plus",
         "haumea": "haumea",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_3"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1747505540,
@@ -799,7 +860,7 @@
     },
     "nixago": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "nixago-exts": "nixago-exts",
         "nixpkgs": [
           "nixpkgs"
@@ -821,7 +882,7 @@
     },
     "nixago-exts": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_6",
         "nixago": "nixago_2",
         "nixpkgs": [
           "nixago",
@@ -844,7 +905,7 @@
     },
     "nixago-exts_2": {
       "inputs": {
-        "flake-utils": "flake-utils_7",
+        "flake-utils": "flake-utils_8",
         "nixago": "nixago_3",
         "nixpkgs": [
           "nixago",
@@ -869,7 +930,7 @@
     },
     "nixago_2": {
       "inputs": {
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_7",
         "nixago-exts": "nixago-exts_2",
         "nixpkgs": [
           "nixago",
@@ -894,7 +955,7 @@
     },
     "nixago_3": {
       "inputs": {
-        "flake-utils": "flake-utils_8",
+        "flake-utils": "flake-utils_9",
         "nixpkgs": [
           "nixago",
           "nixago-exts",
@@ -923,7 +984,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_4",
+        "systems": "systems_5",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -953,6 +1014,22 @@
         "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-deno": {
+      "locked": {
+        "lastModified": 1732443528,
+        "narHash": "sha256-Azj+5Q/jwwTk4nynUBUuzjNj6LAwqHquForethKFbgA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "47ebca5fe22ffc9566e7d2ec11245a9db0135716",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "47ebca5fe22ffc9566e7d2ec11245a9db0135716",
         "type": "github"
       }
     },
@@ -1080,6 +1157,7 @@
         "catppuccin-fractal-wallpapers": "catppuccin-fractal-wallpapers",
         "catppuccin-ohmyrepl": "catppuccin-ohmyrepl",
         "catppuccin-prismlauncher": "catppuccin-prismlauncher",
+        "catppuccin-userstyles-nix": "catppuccin-userstyles-nix",
         "devshell": "devshell",
         "disko": "disko",
         "ez-configs": "ez-configs",
@@ -1111,7 +1189,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_5"
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1747355848,
@@ -1149,7 +1227,7 @@
         "nur": [
           "nur"
         ],
-        "systems": "systems_6",
+        "systems": "systems_7",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
@@ -1203,16 +1281,16 @@
     },
     "systems_2": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default",
+        "repo": "default-linux",
         "type": "github"
       }
     },
@@ -1241,8 +1319,9 @@
         "type": "github"
       },
       "original": {
-        "id": "systems",
-        "type": "indirect"
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "systems_5": {
@@ -1255,9 +1334,8 @@
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "id": "systems",
+        "type": "indirect"
       }
     },
     "systems_6": {
@@ -1276,6 +1354,21 @@
       }
     },
     "systems_7": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_8": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1437,7 +1530,7 @@
     },
     "utils": {
       "inputs": {
-        "systems": "systems_7"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1689068808,

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,12 @@
     # Provides a binary cache, so do not follow inputs
     catppuccin.url = "github:catppuccin/nix";
 
+    # Pre-compiled Stylus Catppuccin userstyles
+    catppuccin-userstyles-nix = {
+      url = "github:different-name/catppuccin-userstyles-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Extra Catppuccin themes
     catppuccin-ohmyrepl = {
       url = "github:catppuccin/ohmyrepl";

--- a/home-modules/librewolf.nix
+++ b/home-modules/librewolf.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  inputs,
   ...
 }:
 {
@@ -25,6 +26,32 @@
             lockPref("${name}", ${builtins.toJSON value}); 
           '') prefs
         );
+
+      # Precompiled stylus settings with catppuccin themes
+      inherit (inputs.catppuccin-userstyles-nix.packages.${pkgs.system}) catppuccin-stylus-storage;
+
+      userstylesOptions = {
+        # Apply settings globally
+        global = {
+          lightFlavor = "latte";
+          darkFlavor = "mocha";
+          accentColor = "red";
+        };
+
+        # Apply settings per userstyle
+        # "Userstyle GitHub Catppuccin" = {
+        #   darkFlavor = "frappe";
+        #   accentColor = "mauve";
+        # };
+      };
+
+      stylusCatppuccinSettings =
+        lib.pipe (catppuccin-stylus-storage.override { inherit userstylesOptions; })
+          [
+            (dir: dir + /share/storage.js)
+            builtins.readFile
+            builtins.fromJSON
+          ];
     in
     {
       enable = true;
@@ -201,11 +228,10 @@
                 };
 
                 # Stylus
-                # TODO: figure out how to populate with Catppuccin userstyles
                 "{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}" = {
                   force = true;
-                  settings = {
-                    dbInChromeStorage = true; # required for Stylus
+                  settings = stylusCatppuccinSettings // {
+                    # (Optional) Set extra settings here
                   };
                 };
 


### PR DESCRIPTION
Was searching through GitHub looking to see if anyone had done this already and saw you were looking to set it up, figured I would make a PR once I figured it out :heart:

This uses a small tool I wrote to build and package the Catppuccin Userstyles source files into the format used by Stylus internally

https://github.com/different-name/catppuccin-userstyles-nix

I haven't tested the changes made in this PR, however this was tested on my personal flake:

https://github.com/different-name/nix-files/commit/d301908cf85de4ba45334e46be4bc4195778b39d